### PR TITLE
perf: add 500ms debounce to NuGet search to prevent spam

### DIFF
--- a/src/UI/Components/NuGetSearchModal.cs
+++ b/src/UI/Components/NuGetSearchModal.cs
@@ -17,6 +17,7 @@ public class NuGetSearchModal : Modal
     private string? _statusMessage;
     private int _lastFrameIndex = -1;
     private CancellationTokenSource? _searchCts;
+    private CancellationTokenSource? _debounceCts;
 
     public NuGetSearchModal(
         Func<SearchResult, Task> onSelected,
@@ -70,6 +71,34 @@ public class NuGetSearchModal : Modal
         }, k => k is { Key: ConsoleKey.PageDown, Modifiers: 0 } || (k.Modifiers == ConsoleModifiers.Control && k.Key == ConsoleKey.D), true);
     }
 
+    private void RestartDebounceTimer()
+    {
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = new CancellationTokenSource();
+        var token = _debounceCts.Token;
+
+        _statusMessage = "Typing...";
+        _requestRefresh();
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(500, token);
+
+                if (!token.IsCancellationRequested)
+                {
+                    TriggerSearch();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Task was cancelled, ignore.
+            }
+        }, token);
+    }
+
     public override async Task<bool> HandleInputAsync(ConsoleKeyInfo key)
     {
         if (await base.HandleInputAsync(key))
@@ -77,6 +106,10 @@ public class NuGetSearchModal : Modal
             if (_searchCts != null)
             {
                 await _searchCts.CancelAsync();
+            }
+            if (_debounceCts != null)
+            {
+                await _debounceCts.CancelAsync();
             }
             return true;
         }
@@ -99,8 +132,7 @@ public class NuGetSearchModal : Modal
         if (!changed)
             return false;
 
-        _searchList.Clear();
-        TriggerSearch();
+        RestartDebounceTimer();
         return true;
 
     }
@@ -114,12 +146,14 @@ public class NuGetSearchModal : Modal
 
         if (string.IsNullOrWhiteSpace(_searchQuery))
         {
+            _searchList.Clear();
             _statusMessage = null;
             _isSearching = false;
             _requestRefresh();
             return;
         }
 
+        _searchList.Clear();
         _isSearching = true;
         _statusMessage = "Typing...";
         _requestRefresh();

--- a/src/UI/Components/NuGetSearchModal.cs
+++ b/src/UI/Components/NuGetSearchModal.cs
@@ -17,7 +17,6 @@ public class NuGetSearchModal : Modal
     private string? _statusMessage;
     private int _lastFrameIndex = -1;
     private CancellationTokenSource? _searchCts;
-    private CancellationTokenSource? _debounceCts;
 
     public NuGetSearchModal(
         Func<SearchResult, Task> onSelected,
@@ -71,34 +70,6 @@ public class NuGetSearchModal : Modal
         }, k => k is { Key: ConsoleKey.PageDown, Modifiers: 0 } || (k.Modifiers == ConsoleModifiers.Control && k.Key == ConsoleKey.D), true);
     }
 
-    private void RestartDebounceTimer()
-    {
-        _debounceCts?.Cancel();
-        _debounceCts?.Dispose();
-        _debounceCts = new CancellationTokenSource();
-        var token = _debounceCts.Token;
-
-        _statusMessage = "Typing...";
-        _requestRefresh();
-
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await Task.Delay(500, token);
-
-                if (!token.IsCancellationRequested)
-                {
-                    TriggerSearch();
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                // Task was cancelled, ignore.
-            }
-        }, token);
-    }
-
     public override async Task<bool> HandleInputAsync(ConsoleKeyInfo key)
     {
         if (await base.HandleInputAsync(key))
@@ -106,10 +77,6 @@ public class NuGetSearchModal : Modal
             if (_searchCts != null)
             {
                 await _searchCts.CancelAsync();
-            }
-            if (_debounceCts != null)
-            {
-                await _debounceCts.CancelAsync();
             }
             return true;
         }
@@ -132,9 +99,8 @@ public class NuGetSearchModal : Modal
         if (!changed)
             return false;
 
-        RestartDebounceTimer();
+        TriggerSearch();
         return true;
-
     }
 
     private void TriggerSearch()
@@ -153,8 +119,7 @@ public class NuGetSearchModal : Modal
             return;
         }
 
-        _searchList.Clear();
-        _isSearching = true;
+        _isSearching = false;
         _statusMessage = "Typing...";
         _requestRefresh();
 
@@ -165,6 +130,8 @@ public class NuGetSearchModal : Modal
                 await Task.Delay(500, token);
                 if (token.IsCancellationRequested) return;
 
+                _isSearching = true;
+                _searchList.Clear();
                 _statusMessage = "Searching...";
                 _requestRefresh();
 


### PR DESCRIPTION
Previously, the **NuGetSearchModal** fired a search task on every single keystroke. This caused UI flickering and unnecessarily spammed the NuGet API while the user was still actively typing.

**Changes**

- Introduced a _debounceCts (CancellationTokenSource) in HandleInputAsync.
- Added a 500ms debounce delay so TriggerSearch() only fires when the user pauses typing.
- Moved _searchList.Clear() to only trigger after the debounce to prevent the UI from clearing existing results while typing.

**Testing**

Tested locally. The search now waits smoothly for the user to finish typing before updating the list.