### PR TITLE
Fix '?' help keybinding not working on Windows 11

### DIFF
--- a/src/Screens/DashboardScreen.cs
+++ b/src/Screens/DashboardScreen.cs
@@ -311,7 +311,7 @@ public class DashboardScreen : IScreen
         {
             ShowHelpModal();
             return Task.CompletedTask;
-        }, k => k is { KeyChar: '?', Modifiers: 0 });
+        }, k => k.KeyChar == '?');
     }
 
     public void StartSearch()

--- a/tests/lazydotnet.UnitTests/DashboardScreenTests.cs
+++ b/tests/lazydotnet.UnitTests/DashboardScreenTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using lazydotnet.Screens;
+using lazydotnet.Services;
+using lazydotnet.UI;
+using NSubstitute;
+
+namespace lazydotnet.UnitTests;
+
+public class DashboardScreenTests
+{
+    private static DashboardScreen CreateScreen()
+    {
+        var editorService = Substitute.For<IEditorService>();
+        var solutionService = new SolutionService();
+        var explorer = new SolutionExplorer(editorService);
+        var detailsPane = new ProjectDetailsPane(solutionService, editorService);
+        var layout = new AppLayout();
+        return new DashboardScreen(explorer, detailsPane, layout, solutionService, ".", null);
+    }
+
+    [Theory]
+    [InlineData('?', ConsoleKey.Oem2, false, false, false, true)]  // Windows: Shift+/
+    [InlineData('?', ConsoleKey.Oem2, true, false, false, true)]   // Linux/Mac: no Shift in modifiers
+    [InlineData('/', ConsoleKey.Oem2, false, false, false, false)] // Plain / without Shift
+    [InlineData('\0', ConsoleKey.Oem2, false, false, true, false)] // Ctrl+Shift+/ → KeyChar is '\0', not '?'
+    [InlineData('\0', ConsoleKey.Oem2, false, true, false, false)] // Alt+Shift+/ → KeyChar is '\0', not '?'
+    public void HelpKeyBinding_Match_ShouldOnlyTriggerOnQuestionMark(
+        char keyChar,
+        ConsoleKey key,
+        bool shift,
+        bool alt,
+        bool control,
+        bool expected)
+    {
+        var screen = CreateScreen();
+        var binding = screen.GetKeyBindings().First(b => b.Label == "?");
+        var keyInfo = new ConsoleKeyInfo(keyChar, key, shift, alt, control);
+
+        binding.Match(keyInfo).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
On Windows, typing '?' requires Shift+/, which sets ConsoleModifiers.Shift. The previous match condition required Modifiers: 0, causing it to never match. Fix by matching on KeyChar only, ignoring modifiers.