### PR TITLE
fix(nix): fix broken nix build

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,48 @@
+name: Nix CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.csproj'
+      - '**/Directory.Build.props'
+      - '**/Directory.Packages.props'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/nix.yml'
+  pull_request:
+    paths:
+      - '**/*.csproj'
+      - '**/Directory.Build.props'
+      - '**/Directory.Packages.props'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/nix.yml'
+
+jobs:
+  nix-build-and-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Fetch Nix Dependencies
+        run: nix run .#fetch-deps -- nix/deps.json
+
+      - name: Auto-commit nix/deps.json
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(nix): auto-update nix/deps.json hashes"
+          file_pattern: "nix/deps.json"
+          
+      - name: Build Nix package
+        run: nix build .

--- a/README.md
+++ b/README.md
@@ -34,8 +34,22 @@ nix profile install github:ckob/lazydotnet
 nix run github:ckob/lazydotnet
 ```
 
-See [`nix/README.md`](nix/README.md) for the dev shell and for regenerating
-`deps.json` after changing NuGet references.
+To add as a flake input in your NixOS or home-manager configuration:
+
+```nix
+# flake.nix
+inputs.lazydotnet.url = "github:ckob/lazydotnet";
+```
+
+```nix
+# home-manager module
+home.packages = [
+  inputs.lazydotnet.packages.${pkgs.stdenv.hostPlatform.system}.lazydotnet
+];
+```
+
+See [`nix/README.md`](nix/README.md) for full details including the dev shell,
+regenerating `deps.json`, and notes on runtime behaviour.
 
 ### Optional Dependencies
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,10 +32,13 @@
           projectFile = "src/lazydotnet.csproj";
           testProjectFile = "tests/lazydotnet.UnitTests/lazydotnet.UnitTests.csproj";
 
-          # Regenerate via: nix run .#packages.${system}.lazydotnet.fetch-deps
+          # Regenerate via: nix run .#fetch-deps
           nugetDeps = ./nix/deps.json;
 
           inherit dotnet-sdk dotnet-runtime;
+
+          # git is required by MinVer to determine the version from tags
+          nativeBuildInputs = [ pkgs.git ];
 
           executables = [ "lazydotnet" ];
 
@@ -59,6 +62,11 @@
           name = "lazydotnet";
         };
         apps.default = apps.lazydotnet;
+
+        apps.fetch-deps = {
+          type = "app";
+          program = "${packages.lazydotnet.fetch-deps}";
+        };
 
         devShells.default = pkgs.mkShell {
           packages = [

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,14 @@
           if pkgs.dotnetCorePackages ? runtime_10_0
           then pkgs.dotnetCorePackages.runtime_10_0
           else pkgs.dotnetCorePackages.runtime_9_0;
+
+        # lazydotnet uses Microsoft.Build.Locator at runtime to discover and
+        # parse .NET solutions, which requires a full SDK installation.
+        # The combined package includes both the SDK and runtime.
+        dotnet-combined = pkgs.dotnetCorePackages.combinePackages [
+          dotnet-sdk
+          dotnet-runtime
+        ];
       in
       rec {
         packages.lazydotnet = pkgs.buildDotnetModule {
@@ -35,7 +43,8 @@
           # Regenerate via: nix run .#fetch-deps
           nugetDeps = ./nix/deps.json;
 
-          inherit dotnet-sdk dotnet-runtime;
+          inherit dotnet-sdk;
+          dotnet-runtime = dotnet-combined;
 
           # git is required by MinVer to determine the version from tags
           nativeBuildInputs = [ pkgs.git ];

--- a/flake.nix
+++ b/flake.nix
@@ -21,14 +21,6 @@
           if pkgs.dotnetCorePackages ? runtime_10_0
           then pkgs.dotnetCorePackages.runtime_10_0
           else pkgs.dotnetCorePackages.runtime_9_0;
-
-        # lazydotnet uses Microsoft.Build.Locator at runtime to discover and
-        # parse .NET solutions, which requires a full SDK installation.
-        # The combined package includes both the SDK and runtime.
-        dotnet-combined = pkgs.dotnetCorePackages.combinePackages [
-          dotnet-sdk
-          dotnet-runtime
-        ];
       in
       rec {
         packages.lazydotnet = pkgs.buildDotnetModule {
@@ -43,8 +35,12 @@
           # Regenerate via: nix run .#fetch-deps
           nugetDeps = ./nix/deps.json;
 
-          inherit dotnet-sdk;
-          dotnet-runtime = dotnet-combined;
+          inherit dotnet-sdk dotnet-runtime;
+
+          # lazydotnet uses Microsoft.Build.Locator at runtime to discover SDKs.
+          # useDotnetFromEnv makes the wrapper prefer the dotnet on PATH (i.e.
+          # the system-installed SDK), falling back to dotnet-runtime if absent.
+          useDotnetFromEnv = true;
 
           # git is required by MinVer to determine the version from tags
           nativeBuildInputs = [ pkgs.git ];

--- a/nix/README.md
+++ b/nix/README.md
@@ -39,13 +39,7 @@ project, regenerate the NuGet lockfile so Nix can fetch packages in offline
 sandbox mode:
 
 ```bash
-nix run .#packages.$(nix eval --raw --impure --expr builtins.currentSystem).lazydotnet.fetch-deps
-```
-
-Or simpler, on most systems:
-
-```bash
-nix run '.#lazydotnet.fetch-deps'
+nix run .#fetch-deps
 ```
 
 The script writes the updated lockfile to a temp path; copy it back:

--- a/nix/README.md
+++ b/nix/README.md
@@ -16,6 +16,25 @@ Or run without installing:
 nix run github:ckob/lazydotnet
 ```
 
+### As a flake input
+
+Add to your `flake.nix` inputs:
+
+```nix
+lazydotnet.url = "github:ckob/lazydotnet";
+```
+
+Then reference the package in your configuration:
+
+```nix
+home.packages = [
+  inputs.lazydotnet.packages.${pkgs.stdenv.hostPlatform.system}.lazydotnet
+];
+```
+
+The binary uses the `dotnet` SDK already on your `PATH` at runtime, so no
+additional .NET installation is required if you already have one configured.
+
 ### Local build
 
 ```bash
@@ -50,3 +69,6 @@ Then commit `nix/deps.json`.
   is not yet packaged in the channel you track.
 - The package is a global tool (`PackAsTool=true`). The flake outputs a single
   executable at `$out/bin/lazydotnet`.
+- `useDotnetFromEnv` is enabled so the wrapper resolves `DOTNET_ROOT` from the
+  `dotnet` binary on `PATH` at invocation time, falling back to the bundled
+  runtime if none is found.

--- a/nix/README.md
+++ b/nix/README.md
@@ -39,13 +39,7 @@ project, regenerate the NuGet lockfile so Nix can fetch packages in offline
 sandbox mode:
 
 ```bash
-nix run .#fetch-deps
-```
-
-The script writes the updated lockfile to a temp path; copy it back:
-
-```bash
-cp /tmp/lazydotnet-deps.json nix/deps.json
+nix run .#fetch-deps -- nix/deps.json
 ```
 
 Then commit `nix/deps.json`.

--- a/nix/deps.json
+++ b/nix/deps.json
@@ -1,1 +1,382 @@
-[]
+[
+  {
+    "pname": "Castle.Core",
+    "version": "5.1.1",
+    "hash": "sha256-oVkQB+ON7S6Q27OhXrTLaxTL0kWB58HZaFFuiw4iTrE="
+  },
+  {
+    "pname": "CliWrap",
+    "version": "3.10.2",
+    "hash": "sha256-PtRWN6tfZ/uT6o1JrLDj624feJgD5iDS4ywsYwEhQ6c="
+  },
+  {
+    "pname": "coverlet.collector",
+    "version": "10.0.1",
+    "hash": "sha256-6nZ5qWvy1SPYM9SfYbZEdGGrErdnOPluZXgJJ/hiarw="
+  },
+  {
+    "pname": "FluentAssertions",
+    "version": "8.10.0",
+    "hash": "sha256-402BFKkp+vFPQX+UbYYYUy1/94/t2pUZxmt65BZOSWU="
+  },
+  {
+    "pname": "MessagePack",
+    "version": "2.5.302",
+    "hash": "sha256-Dx/ofFClAvm+7NhI4k1OjNMIYAksRJcnFtmP0wPrgZ0="
+  },
+  {
+    "pname": "MessagePack.Annotations",
+    "version": "2.5.302",
+    "hash": "sha256-4RIgRR1NctocYHAqzVqjEG/Xw/qNev/d4erkUNQHVbI="
+  },
+  {
+    "pname": "Microsoft.ApplicationInsights",
+    "version": "2.23.0",
+    "hash": "sha256-5sf3bg7CZZjHseK+F3foOchEhmVeioePxMZVvS6Rjb0="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "6.0.0",
+    "hash": "sha256-49+H/iFwp+AfCICvWcqo9us4CzxApPKC37Q5Eqrw+JU="
+  },
+  {
+    "pname": "Microsoft.Build",
+    "version": "18.7.1",
+    "hash": "sha256-SuiMJA9ZSVRMgWCSuqmI+utYuccmObKGcXr6c2zvPDg="
+  },
+  {
+    "pname": "Microsoft.Build.Framework",
+    "version": "18.7.1",
+    "hash": "sha256-reiTfnhkYsgfMBlcyGpDICzVtmJaAt0iOjiq9vg9owg="
+  },
+  {
+    "pname": "Microsoft.Build.Locator",
+    "version": "1.11.2",
+    "hash": "sha256-1eY1hJ9ttRjj5np9DIt3GTnerDI0wToD/CNS3A7BBQI="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "18.6.0",
+    "hash": "sha256-rxJjgFmEmS9+zzocT279IfR7J0pOhDZE527bvkttKBg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "10.0.9",
+    "hash": "sha256-4d8r6Vyune1Qb0kwqzfGPA7BK2nvaiOenTiJedzq6sU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "10.0.9",
+    "hash": "sha256-pliaksEAQdxyPURUVSlXpfF3LzJB93zHaeEDsaF5QJE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "10.0.9",
+    "hash": "sha256-ouJa+84H/bfMi67v25hjEWhTIyBHaWTJAoEvArwbrGA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.EnvironmentVariables",
+    "version": "10.0.9",
+    "hash": "sha256-TqmySse14myFWrrLbNSQD7bTvzT/ZQ24wcpykIe8XOo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.FileExtensions",
+    "version": "10.0.9",
+    "hash": "sha256-r120E0PUCGIh8CsZnzqDlZ7ikbT8Bg/wVYB/g+JJ7D4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Json",
+    "version": "10.0.9",
+    "hash": "sha256-vlH4uDfclV9i7zLeeSF0a/pCiFDdg4mDyHjk0O2KM80="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "10.0.9",
+    "hash": "sha256-YIqgDknwTq48X88Imdrfav3tmQ6tZwIOYsLt6dT40M8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "10.0.9",
+    "hash": "sha256-YzQpGAsrjLU18s016LmM7DMJKml0MzKl1bPPYJ/erEk="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "7.0.0",
+    "hash": "sha256-55lsa2QdX1CJn1TpW1vTnkvbGXKCeE9P0O6AkW49LaA="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "10.0.9",
+    "hash": "sha256-slMiJSmykMXcy0pu/uvoCaOw7BiyBUZQWZ216ERhZok="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Physical",
+    "version": "10.0.9",
+    "hash": "sha256-14V+vnaNyZeNf3pSqFQkxEpuy9WXm+Jo3llmm4UE2Y4="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileSystemGlobbing",
+    "version": "10.0.9",
+    "hash": "sha256-+8gYl7xPmeTD5UazeddRKSfMttCDCoLyhNssP0Ddk04="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.9",
+    "hash": "sha256-/fc1g1SDJI81nOZRS7W4LZIAC0ssmasqaWhgJK+9rRs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "10.0.9",
+    "hash": "sha256-XVKJrNjPo0hojY5V4xoLxedpvkqtr4GJqkCUhLKSTcQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.9",
+    "hash": "sha256-WEPtmlEexm6QSFR4ITlBHuUD5/bqMfecOxFe5hkbAPU="
+  },
+  {
+    "pname": "Microsoft.NET.StringTools",
+    "version": "18.7.1",
+    "hash": "sha256-sTEk+neir/Qbrn93/T1C3qUl25J0kvD/Mf6ojoBgzQc="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "18.6.0",
+    "hash": "sha256-tzlCrp1WgmQdB05yJpib6PeGkH0juPUrw4wu/79H7yw="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.Telemetry",
+    "version": "1.9.1",
+    "hash": "sha256-IlzmkqDCsiJlsbg2OQ/cTgs72dzUHYdAWv9jAbhTZWw="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.TrxReport.Abstractions",
+    "version": "1.9.1",
+    "hash": "sha256-4nIRA7gBhjcYZqAPK06EM2OzlhBrCzVWmszCyEp0Eso="
+  },
+  {
+    "pname": "Microsoft.Testing.Platform",
+    "version": "1.9.1",
+    "hash": "sha256-3MemlXgL8sDuTwbzDPCroYRbxHafo2R4rEuHV59Xm3Y="
+  },
+  {
+    "pname": "Microsoft.Testing.Platform.MSBuild",
+    "version": "1.9.1",
+    "hash": "sha256-5lZwc0bDtmHey1dPJ5cT7A5G2E5Molk6EoVHm+7vxWc="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "18.6.0",
+    "hash": "sha256-Q+GpQZxEw0g/tUsQBkTWtRtbwljCum3LimIuqTELWQo="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "18.6.0",
+    "hash": "sha256-Ez1zC2QiamrlgXO/LlKuLGnD7wJFrWk8w5zYlSkwyJw="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TranslationLayer",
+    "version": "18.6.0",
+    "hash": "sha256-3qRIHBF9ch9CbkwVJmyVzG3R7+eDcXhnan6wnyBihO4="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.SolutionPersistence",
+    "version": "1.0.52",
+    "hash": "sha256-KZGPtOXe6Hv8RrkcsgoLKTRyaCScIpQEa2NhNB3iOXw="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.Threading.Only",
+    "version": "17.13.61",
+    "hash": "sha256-OhXEAuF9PZAkZuHqHwdVODLjA/rIMqmD7nXJfVAQWA8="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.Threading.Only",
+    "version": "17.14.15",
+    "hash": "sha256-o15PJKoIqyfgP2jqybgkydc8bKVZUpCCcrPR05rO7k4="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.Validation",
+    "version": "17.13.22",
+    "hash": "sha256-ArINoBy7Q8bTCVPM9/y8MH0pe8TkhaYrH9PjrZijnY0="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.Validation",
+    "version": "17.8.8",
+    "hash": "sha256-sB8GLRiJHX3Py7qeBUnUANiDWhyPtISon6HQs+8wKms="
+  },
+  {
+    "pname": "Microsoft.Win32.Registry",
+    "version": "5.0.0",
+    "hash": "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA="
+  },
+  {
+    "pname": "MinVer",
+    "version": "7.0.0",
+    "hash": "sha256-cj7+c2Mhn88ljnLepg/0HMPJto5yTTSbspia/TRu1es="
+  },
+  {
+    "pname": "Namotion.Reflection",
+    "version": "3.5.0",
+    "hash": "sha256-jNvNITZf2U+NQ60uMOLy7Y3Yobl0gjZl/1Xc9z6GvqI="
+  },
+  {
+    "pname": "Nerdbank.MessagePack",
+    "version": "1.2.4",
+    "hash": "sha256-6Cb01QAHuSTVstpcx6aVVpcJEn5kIUa3OgUZmAIh70Q="
+  },
+  {
+    "pname": "Nerdbank.Streams",
+    "version": "2.13.16",
+    "hash": "sha256-VdiB31IDleh/hDFtxAtL2N0WAHo8PgyyyX3Q6/un93A="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "NJsonSchema",
+    "version": "11.6.1",
+    "hash": "sha256-sRzsGJ/avvIKouPPWZB+1grnrcWCVwue8JrVn2lRcd4="
+  },
+  {
+    "pname": "NJsonSchema.Annotations",
+    "version": "11.6.1",
+    "hash": "sha256-IYHI+WMRbIJ8/bovEvoqmM0rJlK7gUVchPJYi8m/41o="
+  },
+  {
+    "pname": "NSubstitute",
+    "version": "5.3.0",
+    "hash": "sha256-fa6Hn9Qmpia2labWOs1Xp2LnJBOHfrWIwxvqKRRccs0="
+  },
+  {
+    "pname": "NuGet.Versioning",
+    "version": "7.6.0",
+    "hash": "sha256-HmQBQ808F5jGNQ1We6Ry16G98kPnBVoyoZ8oTyOGoiQ="
+  },
+  {
+    "pname": "PolyType",
+    "version": "1.3.1",
+    "hash": "sha256-J/7MGrY/O0MW429HtRFHPbOD21XLa0c1XSg+wJFky4w="
+  },
+  {
+    "pname": "SonarAnalyzer.CSharp",
+    "version": "10.27.0.140913",
+    "hash": "sha256-H+jDnYbkuLSnxqJv5AKRJLJ04OlSUW7WgOzrn6Or+3A="
+  },
+  {
+    "pname": "Spectre.Console",
+    "version": "0.55.0",
+    "hash": "sha256-YPW3qtPFW2Hud+y6vmZidrD8a42oDJefPW8MIwdb4rs="
+  },
+  {
+    "pname": "Spectre.Console",
+    "version": "0.57.0",
+    "hash": "sha256-U9laoSO2qC3SDBc4ZAMN0st4WOWqSy7lV/Dq0DsW02c="
+  },
+  {
+    "pname": "Spectre.Console.Ansi",
+    "version": "0.57.0",
+    "hash": "sha256-3qRoj08CoKPCCqJW2NN8BFb/hhnV6oHz6okfcn9tY20="
+  },
+  {
+    "pname": "Spectre.Console.Cli",
+    "version": "0.55.0",
+    "hash": "sha256-VJvGl38caKtrLqc1P8HMG8T2Ny2OgEumZzqk2rUcJNw="
+  },
+  {
+    "pname": "StreamJsonRpc",
+    "version": "2.25.29",
+    "hash": "sha256-0Pe+axtiPfY4o1Nx6yl6oPffGP9QVV/JRIVz56XBERs="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "10.0.4",
+    "hash": "sha256-IOgtnN6hHNdoZDDvrIBoMzVp+D1SWJ1LwJ+TIUuE3W8="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "10.0.4",
+    "hash": "sha256-gFbdvani74oe8mLZ7bp4Iz5lfP0dJbc+SaUAyko82PY="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "6.0.0",
+    "hash": "sha256-zUXIQtAFKbiUMKCrXzO4mOTD5EUphZzghBYKXprowSM="
+  },
+  {
+    "pname": "System.Reflection.MetadataLoadContext",
+    "version": "10.0.4",
+    "hash": "sha256-usqt7uNKKWseO94OBJOwPna0lq30W1PhS9MOE+N3VP0="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "10.0.4",
+    "hash": "sha256-aCbQXMJQrDEOGHCwbY36COSkGHBrZfSnPyTrz6P2Al4="
+  },
+  {
+    "pname": "TextCopy",
+    "version": "6.2.1",
+    "hash": "sha256-Lb+e9BwWdRFhxyshIIZAywhDFA5ql3uIV6iQTFUkGUA="
+  },
+  {
+    "pname": "ThisAssembly.AssemblyInfo",
+    "version": "2.1.2",
+    "hash": "sha256-UmEA4ZRnHH3agLeJ+NmnuYFn4mALENMogwAIZtd7SsU="
+  },
+  {
+    "pname": "ThisAssembly.Constants",
+    "version": "2.1.2",
+    "hash": "sha256-SZ1aQW/Ynt9H/gr1N3NYg4D27BBagHpF7OPqOIas6l0="
+  },
+  {
+    "pname": "xunit.analyzers",
+    "version": "1.27.0",
+    "hash": "sha256-RjwU14pgJI+Rp2vMYx/2BgniZ5rNCzow8495Re5hkU4="
+  },
+  {
+    "pname": "xunit.runner.visualstudio",
+    "version": "3.1.5",
+    "hash": "sha256-O5657884QGldszsEWQFCDRTXViFBmZ4GGC+4iU+usSQ="
+  },
+  {
+    "pname": "xunit.v3",
+    "version": "3.2.2",
+    "hash": "sha256-R6I/IJjyimqmLxVNng52Gn5if/Ccd3iiLjdU1fIBRUM="
+  },
+  {
+    "pname": "xunit.v3.assert",
+    "version": "3.2.2",
+    "hash": "sha256-w3darI8cwsPEoKIQW5exkNygGSTimog7i5nCIPt4e8Y="
+  },
+  {
+    "pname": "xunit.v3.common",
+    "version": "3.2.2",
+    "hash": "sha256-kOWWD94aUCCDozO+db8Fyw3hGwNHFDXDGsSK07xfEpA="
+  },
+  {
+    "pname": "xunit.v3.core.mtp-v1",
+    "version": "3.2.2",
+    "hash": "sha256-gX+ThEy/3ZI6HLQX+w7TAgCIEfSl/cYH2hyaGJWoYIM="
+  },
+  {
+    "pname": "xunit.v3.extensibility.core",
+    "version": "3.2.2",
+    "hash": "sha256-IoW/eGhwHJfi4KD9+J+XdhodSc46wz0c6L/oauVO61E="
+  },
+  {
+    "pname": "xunit.v3.mtp-v1",
+    "version": "3.2.2",
+    "hash": "sha256-xLTSJlR2Odqmac3DRTz7lQW6bAQyzuif/mmCHDN73CM="
+  },
+  {
+    "pname": "xunit.v3.runner.common",
+    "version": "3.2.2",
+    "hash": "sha256-mNTM8ubegG11egY55d/27oGDsPUwSxkyczjRbJ1Aweg="
+  },
+  {
+    "pname": "xunit.v3.runner.inproc.console",
+    "version": "3.2.2",
+    "hash": "sha256-G+3n7N4LU+5x/kpC+q7bZ+K1bGp4aLfj0/IEpB3zqJw="
+  }
+]


### PR DESCRIPTION
The initial Nix flake had a few issues that prevented it from building or running correctly.

## Changes

**`nix/deps.json` was empty**

The file was committed as `[]` which caused all NuGet package restores to fail in the sandbox. Regenerated it with all dependencies from both the main project and the test project.

**MinVer requires git**

MinVer calls git to resolve the version from tags during the build phase. Added git to `nativeBuildInputs` so it's available in the sandbox.

**`fetch-deps` wasn't invokable**

`nix run .#packages.${system}.lazydotnet.fetch-deps` would error with "Not a directory". Exposed it as a top-level app so it can be run with: nix run .#fetch-deps -- nix/deps.json

**Binary couldn't locate a .NET SDK at runtime**

lazydotnet uses `Microsoft.Build.Locator` to discover MSBuild assemblies for parsing solutions and projects. The wrapper was pointing `DOTNET_ROOT` at a runtime-only store path with no `sdk/` directory, so locator always failed.

Set `useDotnetFromEnv = true` so the wrapper resolves `DOTNET_ROOT` from the `dotnet` binary already on `PATH` at invocation time, falling back to the bundled runtime if none is found. This also means it naturally picks up whichever SDK version the user has installed rather than being tied to a specific one.

## Testing

Verified with `nix build` and confirmed `lazydotnet --version` runs correctly against a system-installed .NET SDK.