### PR TITLE
feat(nix): update flake with automated version sync

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Resolve checkout ref
+      - name: Resolve Ref
         id: ref
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
@@ -39,7 +39,7 @@ jobs:
             echo "ref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -48,24 +48,24 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Enable Nix Cache
+      - name: Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v14
 
-      - name: Sync version from git tag
+      - name: Sync Version
         if: startsWith(github.ref, 'refs/tags/cli-')
         run: |
           VERSION="${GITHUB_REF_NAME#cli-}"
           sed -i "s/version = \".*\";/version = \"$VERSION\";/" flake.nix
 
-      - name: Fetch Nix Dependencies
+      - name: Fetch Dependencies
         run: nix run .#fetch-deps -- nix/deps.json
 
-      - name: Auto-commit changes
+      - name: Commit Changes
         if: github.event_name == 'push'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(nix): auto-update nix/deps.json hashes"
           file_pattern: "flake.nix nix/deps.json"
 
-      - name: Build Nix package
+      - name: Build
         run: nix build .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -28,11 +28,22 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Resolve checkout ref
+        id: ref
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "ref=main" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ github.head_ref }}" ]]; then
+            echo "ref=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "ref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ startsWith(github.ref, 'refs/tags/') && 'main' || github.head_ref || github.ref_name }}
+          ref: ${{ steps.ref.outputs.ref }}
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,6 +11,8 @@ on:
       - 'flake.nix'
       - 'flake.lock'
       - '.github/workflows/nix.yml'
+    tags:
+      - 'cli-*'
   pull_request:
     paths:
       - '**/*.csproj'
@@ -27,22 +29,32 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ startsWith(github.ref, 'refs/tags/') && 'main' || github.head_ref || github.ref_name }}
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Enable Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+
+      - name: Sync version from git tag
+        if: startsWith(github.ref, 'refs/tags/cli-')
+        run: |
+          VERSION="${GITHUB_REF_NAME#cli-}"
+          sed -i "s/version = \".*\";/version = \"$VERSION\";/" flake.nix
 
       - name: Fetch Nix Dependencies
         run: nix run .#fetch-deps -- nix/deps.json
 
-      - name: Auto-commit nix/deps.json
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Auto-commit changes
+        if: github.event_name == 'push'
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(nix): auto-update nix/deps.json hashes"
-          file_pattern: "nix/deps.json"
-          
+          file_pattern: "flake.nix nix/deps.json"
+
       - name: Build Nix package
         run: nix build .

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,71 +6,55 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-
-        # Prefer .NET 10 SDK if available in nixpkgs, fallback to 9
-        dotnet-sdk =
-          if pkgs.dotnetCorePackages ? sdk_10_0
-          then pkgs.dotnetCorePackages.sdk_10_0
-          else pkgs.dotnetCorePackages.sdk_9_0;
-
-        dotnet-runtime =
-          if pkgs.dotnetCorePackages ? runtime_10_0
-          then pkgs.dotnetCorePackages.runtime_10_0
-          else pkgs.dotnetCorePackages.runtime_9_0;
+        dotnet-sdk = pkgs.dotnetCorePackages.sdk_10_0;
+        dotnet-runtime = pkgs.dotnetCorePackages.runtime_10_0;
       in
       rec {
-        packages.lazydotnet = pkgs.buildDotnetModule {
-          pname = "lazydotnet";
-          version = "0.1.0";
-
-          src = ./.;
-
-          projectFile = "src/lazydotnet.csproj";
-          testProjectFile = "tests/lazydotnet.UnitTests/lazydotnet.UnitTests.csproj";
-
-          # Regenerate via: nix run .#fetch-deps
-          nugetDeps = ./nix/deps.json;
-
-          inherit dotnet-sdk dotnet-runtime;
-
-          # lazydotnet uses Microsoft.Build.Locator at runtime to discover SDKs.
-          # useDotnetFromEnv makes the wrapper prefer the dotnet on PATH (i.e.
-          # the system-installed SDK), falling back to dotnet-runtime if absent.
-          useDotnetFromEnv = true;
-
-          # git is required by MinVer to determine the version from tags
-          nativeBuildInputs = [ pkgs.git ];
-
-          executables = [ "lazydotnet" ];
-
-          # Skip integration tests at build time (require external test binaries)
-          doCheck = true;
-
-          meta = with pkgs.lib; {
-            description = "Terminal UI for .NET solutions, inspired by lazygit";
-            homepage = "https://github.com/ckob/lazydotnet";
-            license = licenses.mit;
-            mainProgram = "lazydotnet";
-            platforms = platforms.unix;
-            maintainers = [ ];
+        packages.lazydotnet =
+          let
+            version = "0.8.1";
+          in
+          pkgs.buildDotnetModule {
+            inherit version dotnet-sdk dotnet-runtime;
+            pname = "lazydotnet";
+            src = ./.;
+            projectFile = "src/lazydotnet.csproj";
+            testProjectFile = "tests/lazydotnet.UnitTests/lazydotnet.UnitTests.csproj";
+            nugetDeps = ./nix/deps.json;
+            useDotnetFromEnv = true;
+            dotnetBuildFlags = [ "/p:MinVerVersion=${version}" ];
+            executables = [ "lazydotnet" ];
+            meta = with pkgs.lib; {
+              description = "Terminal UI for .NET solutions, inspired by lazygit";
+              homepage = "https://github.com/ckob/lazydotnet";
+              license = licenses.mit;
+              mainProgram = "lazydotnet";
+              platforms = platforms.unix;
+            };
           };
-        };
 
         packages.default = packages.lazydotnet;
 
-        apps.lazydotnet = flake-utils.lib.mkApp {
-          drv = packages.lazydotnet;
-          name = "lazydotnet";
-        };
-        apps.default = apps.lazydotnet;
-
-        apps.fetch-deps = {
-          type = "app";
-          program = "${packages.lazydotnet.fetch-deps}";
+        apps = {
+          lazydotnet = flake-utils.lib.mkApp {
+            drv = packages.lazydotnet;
+            name = "lazydotnet";
+          };
+          default = apps.lazydotnet;
+          fetch-deps = {
+            type = "app";
+            program = "${packages.lazydotnet.fetch-deps}";
+          };
         };
 
         devShells.default = pkgs.mkShell {
@@ -87,5 +71,6 @@
         };
 
         formatter = pkgs.nixpkgs-fmt;
-      });
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -15,45 +15,50 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
+        pname = "lazydotnet";
         pkgs = nixpkgs.legacyPackages.${system};
         dotnet-sdk = pkgs.dotnetCorePackages.sdk_10_0;
         dotnet-runtime = pkgs.dotnetCorePackages.runtime_10_0;
       in
       rec {
-        packages.lazydotnet =
+        packages.${pname} =
           let
             version = "0.8.1";
           in
           pkgs.buildDotnetModule {
-            inherit version dotnet-sdk dotnet-runtime;
-            pname = "lazydotnet";
+            inherit
+              pname
+              version
+              dotnet-sdk
+              dotnet-runtime
+              ;
             src = ./.;
-            projectFile = "src/lazydotnet.csproj";
-            testProjectFile = "tests/lazydotnet.UnitTests/lazydotnet.UnitTests.csproj";
+            projectFile = "src/${pname}.csproj";
+            testProjectFile = "tests/${pname}.UnitTests/${pname}.UnitTests.csproj";
             nugetDeps = ./nix/deps.json;
             useDotnetFromEnv = true;
             dotnetBuildFlags = [ "/p:MinVerVersion=${version}" ];
-            executables = [ "lazydotnet" ];
+            executables = [ pname ];
             meta = with pkgs.lib; {
               description = "Terminal UI for .NET solutions, inspired by lazygit";
-              homepage = "https://github.com/ckob/lazydotnet";
+              homepage = "https://github.com/ckob/${pname}";
               license = licenses.mit;
-              mainProgram = "lazydotnet";
+              mainProgram = pname;
               platforms = platforms.unix;
             };
           };
 
-        packages.default = packages.lazydotnet;
+        packages.default = packages.${pname};
 
         apps = {
-          lazydotnet = flake-utils.lib.mkApp {
-            drv = packages.lazydotnet;
-            name = "lazydotnet";
+          ${pname} = flake-utils.lib.mkApp {
+            drv = packages.${pname};
+            name = pname;
           };
-          default = apps.lazydotnet;
+          default = apps.${pname};
           fetch-deps = {
             type = "app";
-            program = "${packages.lazydotnet.fetch-deps}";
+            program = "${packages.${pname}.fetch-deps}";
           };
         };
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Updates the Nix flake for including the version details in the binary when a tag is published.

## What's included

- Added global.json so on nix it'll use the right dotnet sdk binary
- CI workflow (`.github/workflows/nix.yml`) that:
  - .NET 9 fallback removed, .NET 10 only
  - Uses `magic-nix-cache-action` for caching
  - Automatically syncs the version in `flake.nix` when a `cli-*` tag is pushed

No need to make manual version changes yourself in the flake, the nix workflow covers it.